### PR TITLE
add jsConcat Task

### DIFF
--- a/dist/tasks/jsConcat/task.js
+++ b/dist/tasks/jsConcat/task.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = (gulp, config, paths) => {
+  let concatConfig = {
+    sourcemaps: {
+      enabled: false
+    },
+    browserify: {
+      enabled: false
+    },
+    babeljs: {
+      enabled: false,
+      config: {
+        minified: true,
+        comments: false
+      }
+    }
+  };
+
+  require('../js/es')('jsConcat', gulp, concatConfig, paths);
+};

--- a/gulp-config-default.js
+++ b/gulp-config-default.js
@@ -119,6 +119,9 @@ module.exports = {
 				'./src/js/*.js'
 			]
 		},
+		jsConcat: {
+			'./public/js/vendor.js': ['./src/js/vendor/*.js']
+		},
 		images: {
 			'./public/img/': [
 				'./src/img/**/*.jpeg',

--- a/src/tasks/jsConcat/task.js
+++ b/src/tasks/jsConcat/task.js
@@ -1,0 +1,19 @@
+module.exports = (gulp, config, paths) => {
+	let concatConfig = {
+		sourcemaps: {
+			enabled: false
+		},
+		browserify: {
+			enabled: false
+		},
+
+		babeljs: {
+			enabled: false,
+			config: {
+				minified: true,
+				comments: false
+			}
+		}
+	}
+	require('../js/es')('jsConcat', gulp, concatConfig, paths)
+}


### PR DESCRIPTION
Added a task that just concats js-files. Useful for vendor-javascript that just needs to be compiled into one file. Basically this task just calls the regular js task with a predefined config. 