### PR TITLE
Extend defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A fork of [zephir/zephir-gulp-workflow](https://github.com/zephir/zephir-gulp-wo
 - `gulp cleanup` for file removal (sourcemaps)
 - gulp-notify
 - favicons
+- a lot of configuration has defaults
+- `js`and `es6` are the same task, but can have different configurations (e.g. babel or no-babel)
 
 ## conventions
 - config files are located at the root of your `package.json` and are called `gulp-config.js` (not `compileConfig.js` as with `zephir-gulp-workflow`)
@@ -41,7 +43,91 @@ combinedTasks: {
 	default: [["dist", "watch"]], // runs parallel
 },
 ```
+a lot of configurable stuff has defaults, that can be overwritten. These defaults are not in the gulp-config to keep it clean. They can still be readded and overwrite the defaults. The defaults are:  
 
+```js 
+css: {
+	scss: {
+		config: {
+			outputStyle: 'compressed' 				}
+	},
+
+	sourcemaps: {
+		enabled: 'dev'
+	},
+
+	autoprefixer: {
+		enabled: true,
+		config: {
+			browserlist: ['> 0.1%']
+		}
+	},
+
+	cleanCss: {
+		enabled: true,
+		config: {
+			compatibility: 'ie8'
+		}
+	}
+},
+js: {
+	sourcemaps: {
+		enabled: 'dev'
+	},
+	browserify: {
+		enabled: true
+	},
+
+	babeljs: {
+		enabled: true,
+		config: {
+			minified: true,
+			presets: [
+				[
+					'@babel/preset-env',
+					{
+						targets: {
+							browsers: ['> 0.1%']
+						}
+					}
+				]
+			]
+		}
+	}
+},
+images: {
+	imagemin: {
+		enabled: true,
+		config: [
+			imagemin.gifsicle(),
+			imagemin.jpegtran({ progressive: true }),
+			imagemin.optipng({ optimizationLevel: 5 }),
+			imagemin.svgo({ plugins: [{ removeViewBox: true }] })
+		],
+		additional: false
+	}
+},
+
+svg: {
+	svgmin: {
+		enabled: true,
+		config: {}
+	}
+}
+
+``` 
+
+The `favicons`-task has no defaults. Configuration looks like this: 
+
+```js
+favicons: {
+	enabled: true,
+	themeColor: '#cafe23',
+	iconsPath: './',
+	appName: 'FoobarBaz'
+},
+
+```
 ## Usage
 
 Run `gulp dist --env dist` for distribution, otherwise just `gulp`.
@@ -66,6 +152,13 @@ Run test http server with `npm run testd` => <http://localhost:8080>, then look 
 ---
 
 # changelog
+
+## 2.1.5
+- created defaults for a lot of configuration to shrink down `gulp-config.js`
+
+## 2.1.4
+- Updated dependencies
+
 
 ## 2.1.2–2.1.3
 - Updated dependencies + fix pngquant – thank you @hoffmannclaus!

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,9 +29,10 @@ const workflow = gulp => {
   const tasks = fs.readdirSync(`${properties.moduleRootDir}/tasks/`).filter(junk.not); // autorequire
 
   tasks.forEach(task => {
-    let taskFn = require(`./tasks/${task}/task.js`);
+    const taskFn = require(`./tasks/${task}/task.js`);
 
-    taskFn(gulp, config[task], config.paths[task]);
+    const taskConfig = config[task] !== undefined ? config[task] : {};
+    taskFn(gulp, taskConfig, config.paths[task]);
   }); // special watch task
 
   gulp.task('watch', () => {

--- a/dist/tasks/css/task.js
+++ b/dist/tasks/css/task.js
@@ -1,5 +1,11 @@
 "use strict";
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 const sass = require('gulp-sass');
 
 const sourcemaps = require('gulp-sourcemaps');
@@ -27,26 +33,80 @@ module.exports = (gulp, config, paths) => {
       dest = replaceEnv(dest);
       let buffer = gulp.src(source, {
         allowEmpty: true
-      });
+      }); // -------- sourcemaps init ---------
 
-      if (isEnabled(config.sourcemaps.enabled)) {
-        buffer = buffer.pipe(sourcemaps.init());
+      let sourceMapsEnabled = 'dev';
+
+      if (config.sourcemaps !== undefined && config.sourcemaps.enabled !== undefined) {
+        sourceMapsEnabled = config.sourcemaps.enabled;
       }
 
-      buffer = buffer.pipe(sass(config.scss.config).on('error', gnotify.onError({
+      if (isEnabled(sourceMapsEnabled)) {
+        buffer = buffer.pipe(sourcemaps.init());
+      } // -------- scss ---------
+
+
+      let scssConfig = {
+        outputStyle: 'compressed'
+      };
+
+      if (config.scss !== undefined && config.scss.config !== undefined) {
+        scssConfig = _objectSpread({}, scssConfig, {}, config.scss.config);
+      }
+
+      buffer = buffer.pipe(sass(scssConfig).on('error', gnotify.onError({
         message: 'Error: <%= error.message %>',
         emitError: true
-      })));
+      }))); // -------- autoprefixer ---------
 
-      if (isEnabled(config.autoprefixer.enabled)) {
-        buffer = require('./autoprefixer.js')(buffer, config.autoprefixer.config);
+      let autoprefixerEnabled = true;
+      let autoprefixerConfig = {
+        browserlist: ['> 0.1%']
+      };
+
+      if (config.autoprefixer !== undefined) {
+        if (config.autoprefixer.enabled !== undefined) {
+          autoprefixerEnabled = true;
+        }
+
+        if (config.autoprefixer.config !== undefined) {
+          autoprefixerConfig = _objectSpread({}, autoprefixerConfig, {}, config.autoprefixer.config);
+        }
       }
 
-      if (isEnabled(config.cleanCss.enabled)) {
-        buffer = require('./cleanCss.js')(buffer, config.cleanCss.config);
+      if (autoprefixerEnabled) {
+        buffer = require('./autoprefixer.js')(buffer, autoprefixerConfig);
+      } // -------- cleanCSS ---------
+
+
+      let cleanCSSEnabled = true;
+      let cleanCSSConfig = {
+        compatibility: 'ie8'
+      };
+
+      if (config.cleanCss !== undefined) {
+        if (config.cleanCss.enabled !== undefined) {
+          cleanCSSEnabled = config.cleanCss.enabled;
+        }
+
+        if (config.cleanCss.config !== undefined) {
+          cleanCSSConfig = _objectSpread({}, cleanCSSConfig, {}, config.cleanCss.config);
+        }
+      } // disable cleanCSS if we don't want compressed files
+
+
+      if (scssConfig.outputStyle !== 'compressed') {
+        cleanCSSEnabled = false;
+        console.log(scssConfig);
+        console.log('clean css is not run');
       }
 
-      if (isEnabled(config.sourcemaps.enabled)) {
+      if (cleanCSSEnabled) {
+        buffer = require('./cleanCss.js')(buffer, cleanCSSConfig);
+      } // -------- sourcemaps write out ---------
+
+
+      if (isEnabled(sourceMapsEnabled)) {
         buffer = buffer.pipe(sourcemaps.write('.'));
       }
 

--- a/dist/tasks/images/task.js
+++ b/dist/tasks/images/task.js
@@ -25,24 +25,61 @@ module.exports = (gulp, config, paths) => {
       dest = replaceEnv(dest);
       let buffer = gulp.src(source, {
         allowEmpty: true
-      });
+      }); // -------- imagemin ---------
 
-      if (isEnabled(config.imagemin.enabled)) {
-        buffer = buffer.pipe(imagemin(config.imagemin.config)); // pngquant with default options
-
-        let pngquantOptions = {
+      let imageMinEnabled = true;
+      const imageMinConfig = {
+        gifsicle: {},
+        jpegtran: {
+          progressive: true
+        },
+        optipng: {
+          optimizationLevel: 5
+        },
+        pngquant: {
           quality: [0.6, 0.8]
-        };
+        }
+      };
 
-        if (config.imagemin.pngquant !== undefined) {
-          pngquantOptions = config.imagemin.pngquant;
+      if (config.imagemin !== undefined) {
+        if (config.imagemin.enabled !== undefined) {
+          imageMinEnabled = config.imagemin.enabled;
+        } // overwrite from config
+
+
+        if (config.imagemin.config !== undefined) {
+          for (const func in config.imagemin.config) {
+            imageMinConfig[func] = config.imagemin.config[func];
+          }
+        }
+      }
+
+      if (isEnabled(imageMinEnabled)) {
+        // pipe all defined functions
+        if (imageMinConfig.gifsicle !== false) {
+          buffer = buffer.pipe(imagemin([imagemin.gifsicle(imageMinConfig.gifsicle)]));
         }
 
-        buffer = buffer.pipe(imagemin([pngquant(pngquantOptions)], {
-          plugins: [pngquant]
-        }, {
-          verbose: true
-        }));
+        if (imageMinConfig.jpegtran !== false) {
+          buffer = buffer.pipe(imagemin([imagemin.jpegtran(imageMinConfig.jpegtran)]));
+        }
+
+        if (imageMinConfig.optipng !== false) {
+          buffer = buffer.pipe(imagemin([imagemin.optipng(imageMinConfig.optipng)]));
+        }
+
+        if (imageMinConfig.pngquant !== false) {
+          buffer = buffer.pipe(imagemin([pngquant(imageMinConfig.pngquant)], {
+            plugins: [pngquant]
+          }, {
+            verbose: true
+          }));
+        } // and additional functions if needed
+
+
+        if (config.imagemin !== undefined && config.imagemin.additional !== undefined && config.imagemin.additional !== false) {
+          buffer = buffer.pipe(imagemin(config.imagemin.additional));
+        }
       }
 
       buffer = buffer.pipe(gulp.dest(dest)).pipe(touch()).on('error', gnotify.onError({

--- a/dist/tasks/js/es.js
+++ b/dist/tasks/js/es.js
@@ -1,5 +1,11 @@
 "use strict";
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 const babel = require('gulp-babel');
 
 const concat = require('gulp-concat');
@@ -36,13 +42,26 @@ module.exports = (name, gulp, config, paths) => {
 
       let buffer = gulp.src(source, {
         allowEmpty: true
-      });
+      }); // -------- sourcemaps init ---------
 
-      if (isEnabled(config.sourcemaps.enabled)) {
-        buffer = buffer.pipe(sourcemaps.init());
+      let sourceMapsEnabled = 'dev';
+
+      if (config.sourcemaps !== undefined && config.sourcemaps.enabled !== undefined) {
+        sourceMapsEnabled = config.sourcemaps.enabled;
       }
 
-      if (isEnabled(config.browserify.enabled)) {
+      if (isEnabled(sourceMapsEnabled)) {
+        buffer = buffer.pipe(sourcemaps.init());
+      } // -------- browserify ---------
+
+
+      let browserifyEnabled = true;
+
+      if (config.browserify !== undefined && config.browserify.enabled !== undefined) {
+        browserifyEnabled = config.browserify.enabled;
+      }
+
+      if (isEnabled(browserifyEnabled)) {
         buffer = buffer.pipe(browserify().on('error', gnotify.onError({
           message: 'Error: <%= error.message %>',
           emitError: true
@@ -51,16 +70,40 @@ module.exports = (name, gulp, config, paths) => {
 
       if (isFile) {
         buffer = buffer.pipe(concat(file));
+      } // -------- babel ---------
+
+
+      let babeljsEnabled = true;
+      let babeljsConfig = {
+        minified: true,
+        comments: false,
+        presets: [['@babel/preset-env', {
+          targets: {
+            browsers: ['> 0.1%']
+          }
+        }]]
+      };
+
+      if (config.babeljs !== undefined) {
+        if (config.babeljs.enabled !== undefined) {
+          babeljsEnabled = config.babeljs.enabled;
+        }
+
+        if (config.babeljs.config !== undefined) {
+          babeljsConfig = _objectSpread({}, babeljsConfig, {}, config.babeljs.config);
+        }
       }
 
-      if (isEnabled(config.babeljs.enabled)) {
-        buffer = buffer.pipe(babel(config.babeljs.config).on('error', gnotify.onError({
+      if (isEnabled(babeljsEnabled)) {
+        console.log('babel');
+        buffer = buffer.pipe(babel(babeljsConfig).on('error', gnotify.onError({
           message: 'Error: <%= error.message %>',
           emitError: true
         })));
-      }
+      } // -------- sourcemaps write out ---------
 
-      if (isEnabled(config.sourcemaps.enabled)) {
+
+      if (isEnabled(sourceMapsEnabled)) {
         buffer = buffer.pipe(sourcemaps.write('.'));
       }
 

--- a/dist/tasks/svg/task.js
+++ b/dist/tasks/svg/task.js
@@ -21,10 +21,23 @@ module.exports = (gulp, config, paths) => {
       dest = replaceEnv(dest);
       let buffer = gulp.src(source, {
         allowEmpty: true
-      });
+      }); // -------- svgMin ---------
 
-      if (isEnabled(config.svgmin.enabled)) {
-        buffer = buffer.pipe(svgmin(config.svgmin.config));
+      let svgMinEnabled = true;
+      let svgMinConfig = {};
+
+      if (config.svgmin !== undefined) {
+        if (config.svgmin.enabled !== undefined) {
+          svgMinEnabled = config.svgmin.enabled;
+        }
+
+        if (config.svgmin.config !== undefined) {
+          svgMinConfig = config.svgmin.config;
+        }
+      }
+
+      if (isEnabled(svgMinEnabled)) {
+        buffer = buffer.pipe(svgmin(svgMinConfig));
       }
 
       buffer = buffer.pipe(gulp.dest(dest)).pipe(touch());

--- a/gulp-config-default.js
+++ b/gulp-config-default.js
@@ -1,105 +1,6 @@
-const imagemin = require('gulp-imagemin')
-const browserlist = ['> 0.1%']
-
 module.exports = {
-	css: {
-		scss: {
-			config: {
-				outputStyle: 'compressed' // nested, compact, expanded and compressed are available options
-			}
-		},
-
-		sourcemaps: {
-			enabled: 'dev'
-		},
-
-		autoprefixer: {
-			enabled: true,
-			config: {
-				browserlist: browserlist
-			}
-		},
-
-		cleanCss: {
-			enabled: true,
-			config: {
-				compatibility: 'ie8'
-			}
-		}
-	},
-
-	js: {
-		sourcemaps: {
-			enabled: 'dev'
-		},
-		browserify: {
-			enabled: false
-		},
-
-		babeljs: {
-			enabled: true,
-			config: {
-				minified: true,
-				comments: false
-			}
-		}
-	},
-
-	es6: {
-		sourcemaps: {
-			enabled: 'dev'
-		},
-		browserify: {
-			enabled: true
-		},
-
-		babeljs: {
-			enabled: true,
-			config: {
-				minified: true,
-				presets: [
-					[
-						'@babel/preset-env',
-						{
-							targets: {
-								browsers: browserlist
-							}
-						}
-					]
-				]
-			}
-		}
-	},
-
 	clean: {
-		enabled: 'dist',
 		paths: ['./public/**/*.map', './src/tmp']
-	},
-
-	images: {
-		imagemin: {
-			enabled: true,
-			config: [
-				imagemin.gifsicle(),
-				imagemin.jpegtran({ progressive: true }),
-				imagemin.optipng({ optimizationLevel: 5 }),
-				imagemin.svgo({ plugins: [{ removeViewBox: true }] })
-			]
-		}
-	},
-
-	svg: {
-		svgmin: {
-			enabled: true,
-			config: {}
-		}
-	},
-
-	favicons: {
-		enabled: true,
-		themeColor: '#cafe23',
-		iconsPath: './',
-		appName: 'FoobarBaz'
 	},
 
 	paths: {
@@ -107,15 +8,8 @@ module.exports = {
 		css: {
 			'./public/css/': ['./src/scss/**/*.scss']
 		},
-		es6: {
-			'./src/tmp/es6-bundle.js': ['./src/es6/index.js']
-		},
-		es6Watch: {
-			0: ['./src/es6/**/*.js']
-		},
 		js: {
-			'./public/js/script.js': [
-				'./src/tmp/es6-bundle.js',
+			'./public/js/scripts.js': [
 				'./src/js/*.js'
 			]
 		},
@@ -135,15 +29,11 @@ module.exports = {
 		},
 		copy: {
 			'./public/fonts/': ['./src/fonts/**/*.*']
-		},
-		favicons: {
-			'./public/favicons/': ['./src/favicons/**/*.png']
 		}
 	},
 
-	// All tasks above are available (css, js, images and svg)
 	combinedTasks: {
-		dist: ['es6', 'js', 'images', 'svg', 'css', 'copy', 'clean'],
+		dist: ['js', 'images', 'svg', 'css', 'copy', 'clean'],
 		default: [['dist', 'watch']]
 	},
 
@@ -151,7 +41,6 @@ module.exports = {
 		images: ['images'],
 		svg: ['svg'],
 		css: ['css'],
-		es6Watch: ['es6'],
 		js: ['js'],
 		copy: ['copy']
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,9 @@ const workflow = gulp => {
 
 	// autorequire
 	tasks.forEach(task => {
-		let taskFn = require(`./tasks/${task}/task.js`)
-		taskFn(gulp, config[task], config.paths[task])
+		const taskFn = require(`./tasks/${task}/task.js`)
+		const taskConfig = (config[task] !== undefined) ? config[task] : {}
+		taskFn(gulp, taskConfig, config.paths[task])
 	})
 
 	// special watch task

--- a/src/tasks/images/task.js
+++ b/src/tasks/images/task.js
@@ -17,18 +17,48 @@ module.exports = (gulp, config, paths) => {
 
 			let buffer = gulp.src(source, { allowEmpty: true })
 
-			if (isEnabled(config.imagemin.enabled)) {
-				buffer = buffer.pipe(imagemin(config.imagemin.config))
+			// -------- imagemin ---------
+			let imageMinEnabled = true
 
-				// pngquant with default options
-				let pngquantOptions = { quality: [0.6, 0.8] }
-				if (config.imagemin.pngquant !== undefined) {
-					pngquantOptions = config.imagemin.pngquant
+			const imageMinConfig = {
+				gifsicle: {},
+				jpegtran: { progressive: true },
+				optipng: { optimizationLevel: 5 },
+				pngquant: { quality: [0.6, 0.8] }
+			}
+
+			if (config.imagemin !== undefined) {
+				if (config.imagemin.enabled !== undefined) {
+					imageMinEnabled = config.imagemin.enabled
 				}
-				buffer = buffer.pipe(imagemin(
-					[pngquant(pngquantOptions)],
-					{ plugins: [pngquant] },
-					{ verbose: true }))
+				// overwrite from config
+				if (config.imagemin.config !== undefined) {
+					for (const func in config.imagemin.config) {
+						imageMinConfig[func] = config.imagemin.config[func]
+					}
+				}
+			}
+
+			if (isEnabled(imageMinEnabled)) {
+				// pipe all defined functions
+				if (imageMinConfig.gifsicle !== false) {
+					buffer = buffer.pipe(imagemin([imagemin.gifsicle(imageMinConfig.gifsicle)]))
+				}
+				if (imageMinConfig.jpegtran !== false) {
+					buffer = buffer.pipe(imagemin([imagemin.jpegtran(imageMinConfig.jpegtran)]))
+				}
+				if (imageMinConfig.optipng !== false) {
+					buffer = buffer.pipe(imagemin([imagemin.optipng(imageMinConfig.optipng)]))
+				}
+				if (imageMinConfig.pngquant !== false) {
+					buffer = buffer.pipe(imagemin([pngquant(imageMinConfig.pngquant)],
+						{ plugins: [pngquant] },
+						{ verbose: true }))
+				}
+				// and additional functions if needed
+				if (config.imagemin !== undefined && config.imagemin.additional !== undefined && config.imagemin.additional !== false) {
+					buffer = buffer.pipe(imagemin(config.imagemin.additional))
+				}
 			}
 
 			buffer = buffer.pipe(gulp.dest(dest)).pipe(touch()).on(

--- a/src/tasks/svg/task.js
+++ b/src/tasks/svg/task.js
@@ -15,8 +15,19 @@ module.exports = (gulp, config, paths) => {
 
 			let buffer = gulp.src(source, { allowEmpty: true })
 
-			if (isEnabled(config.svgmin.enabled)) {
-				buffer = buffer.pipe(svgmin(config.svgmin.config))
+			// -------- svgMin ---------
+			let svgMinEnabled = true
+			let svgMinConfig = {}
+			if (config.svgmin !== undefined) {
+				if (config.svgmin.enabled !== undefined) {
+					svgMinEnabled = config.svgmin.enabled
+				}
+				if (config.svgmin.config !== undefined) {
+					svgMinConfig = config.svgmin.config
+				}
+			}
+			if (isEnabled(svgMinEnabled)) {
+				buffer = buffer.pipe(svgmin(svgMinConfig))
 			}
 
 			buffer = buffer.pipe(gulp.dest(dest)).pipe(touch())

--- a/test/gulp-config.js
+++ b/test/gulp-config.js
@@ -1,47 +1,70 @@
-const testConfig = require('../gulp-config-default')
+module.exports = {
 
-testConfig.clean = {
-	enabled: true,
-	paths: ['./output/favicons/deleteme.txt', './output/**/*.map']
-}
-
-testConfig.paths = {
-	// "DESTINATION" : ['SOURCE']
-	css: {
-		'./output/css/': ['./input/css/**/*.scss'],
-		'./output/should-not-exist/': ['./input/css/notfound.scss']
-	},
-	es6: {
-		'./input/tmp/': ['./input/es6/index.js'],
-		'./output/should-not-exist/': ['./input/es6/notfound.js']
-	},
-	es6Watch: {
-		watch: ['./input/es6/**/*.js']
-	},
 	js: {
-		'./output/js/script.js': ['./input/tmp/*.js', './input/js/*.js']
+		browserify: {
+			enabled: false
+		}
 	},
-	jsConcat: {
-		'./output/jsConcat/vendor.js': ['./input/jsConcat/**/*.js']
-	},
-	images: {
-		'./output/images/': [
-			'./input/images/**/*.jpeg',
-			'./input/images/**/*.jpg',
-			'./input/images/**/*.png',
-			'./input/images/**/*.gif'
-		]
-	},
-	svg: {
-		'./output/images/': ['./input/images/**/*.svg']
-	},
+
 	favicons: {
-		'./output/favicons/': ['./input/favicons/**/*.png']
+		enabled: true,
+		themeColor: '#cafe23',
+		iconsPath: './',
+		appName: 'FoobarBaz'
+	},
+
+	clean: {
+		paths: ['./output/favicons/deleteme.txt', './output/**/*.map']
+	},
+
+	paths: {
+		css: {
+			'./output/css/': ['./input/css/**/*.scss'],
+			'./output/should-not-exist/': ['./input/css/notfound.scss']
+		},
+		es6: {
+			'./input/tmp/': ['./input/es6/index.js'],
+			'./output/should-not-exist/': ['./input/es6/notfound.js']
+		},
+		es6Watch: {
+			watch: ['./input/es6/**/*.js']
+		},
+		js: {
+			'./output/js/script.js': ['./input/tmp/*.js', './input/js/*.js']
+		},
+		jsConcat: {
+			'./output/jsConcat/vendor.js': ['./input/jsConcat/**/*.js']
+		},
+		images: {
+			'./output/images/': [
+				'./input/images/**/*.jpeg',
+				'./input/images/**/*.jpg',
+				'./input/images/**/*.png',
+				'./input/images/**/*.gif'
+			]
+		},
+		svg: {
+			'./output/images/': ['./input/images/**/*.svg']
+		},
+		favicons: {
+			'./output/favicons/': ['./input/favicons/**/*.png']
+		}
+	},
+
+	combinedTasks: {
+		test: ['es6', 'js', 'jsConcat', 'images', 'svg', 'css', 'copy', 'favicons', 'clean'],
+		testTxt: ['es6', 'js', 'jsConcat', 'css', 'copy', 'clean'],
+		testImg: ['images', 'svg', 'favicons'],
+		dist: ['es6', 'js', 'images', 'svg', 'css', 'copy', 'clean'],
+		default: [['dist', 'watch']]
+	},
+
+	watchTask: {
+		images: ['images'],
+		svg: ['svg'],
+		css: ['css'],
+		es6Watch: ['es6'],
+		js: ['js'],
+		copy: ['copy']
 	}
 }
-
-testConfig.combinedTasks.test = ['es6', 'js', 'jsConcat', 'images', 'svg', 'css', 'copy', 'favicons', 'clean']
-testConfig.combinedTasks.testTxt = ['es6', 'js', 'jsConcat', 'css', 'copy', 'clean']
-testConfig.combinedTasks.testImg = ['images', 'svg', 'favicons']
-
-module.exports = testConfig


### PR DESCRIPTION
- created defaults for all task-options
- cleaned up gulp-config
- workflow can now be run with configured paths only. 
- all defaults can still be overwritten and / or extended. 
- defaults are merged with custom configurations, so it is not necessary to overwrite everything, to only modify single values in the configuration. 